### PR TITLE
Fix deprecated code in goreleaser

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -21,9 +21,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Code Base
-        uses: super-linter/super-linter@v7.2.0
+        uses: super-linter/super-linter@v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_GO: false
-          VALIDATE_GO_MODULES: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
         goarch: "386"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - format: zip
+  - formats: ["zip"]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
@@ -42,5 +42,5 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  # draft: true
+# draft: true
 changelog:

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ lint:
 		-e LOG_LEVEL=${LOG_LEVEL} \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e RUN_LOCAL=true \
+		-e SHELL=/bin/bash \
 		-e DEFAULT_BRANCH=${GIT_BRANCH} \
 		-e VALIDATE_GO=false \
 		-v ${WORKSPACE}:/tmp/lint \
 		ghcr.io/super-linter/super-linter:latest
-


### PR DESCRIPTION
Fix deprecated code in goreleaser
Bump super-linter to version 7.3.0
Enable go modules validation linter
Fix linter on localhost